### PR TITLE
feat(boj): solve 1146 using 3D DP

### DIFF
--- a/BOJ/1146_zigzag.py
+++ b/BOJ/1146_zigzag.py
@@ -1,0 +1,26 @@
+import sys
+input = sys.stdin.readline
+N = int(input())
+MOD = 1_000_000
+if N == 1:
+    print(1)
+    exit(0)
+dp = [[[0] * 2 for _ in range(N + 1)] for __ in range(N + 1)]
+dp[1][1][0] = 1
+dp[1][1][1] = 1
+dp[2][1][0] = 1
+dp[2][2][1] = 1
+for i in range(3, N + 1):
+    for j in range(1, i + 1):
+        s1 = 0
+        for k in range(1, j):
+            s1 += dp[i - 1][k][0]
+        dp[i][j][1] = s1 % MOD
+        s0 = 0
+        for k in range(j, i):
+            s0 += dp[i - 1][k][1]
+        dp[i][j][0] = s0 % MOD
+ans = 0
+for j in range(1, N + 1):
+    ans = (ans + dp[N][j][0] + dp[N][j][1]) % MOD
+print(ans)


### PR DESCRIPTION
## 🧩 문제 정보
**플랫폼:** BOJ  
**번호:** 1146  
**제목:** 지그재그 서기  
**링크:** https://www.acmicpc.net/problem/1146  

## ✨ 해결 방법

> **시작 부등호(< 또는 >)까지 상태로 포함한 3차원 DP(dp[i][j][s])를 사용해 지그재그 순열의 개수를 계산했다.**

- 상태 정의: `dp[i][j][s]`
  - `i` : 1부터 i까지의 수를 사용하여 만든 지그재그 수열
  - `j` : 해당 수열에서 **맨 앞에 오는 숫자**
  - `s` : 처음 부등호 방향  
    - `0` = `<` 로 시작하는 패턴  
    - `1` = `>` 로 시작하는 패턴

- 점화식 개요:
  - `s = 1` (처음 `>` 시작)  
    → 다음 비교는 `<` 이어야 함  
    → `dp[i][j][1] = sum(dp[i - 1][k][0])` for `1 ≤ k < j`

  - `s = 0` (처음 `<` 시작)  
    → 다음 비교는 `>` 이어야 함  
    → `dp[i][j][0] = sum(dp[i - 1][k][1])` for `j ≤ k < i`

- 기저값:
  - `dp[1][1][0] = dp[1][1][1] = 1`
  - `dp[2][1][0] = 1`  
  - `dp[2][2][1] = 1`

- 최종 결과 계산:
  ```python
  ans = sum(dp[N][j][0] + dp[N][j][1] for j in range(1, N + 1)) % 1_000_000

## ⏱️ 복잡도
- 시간 복잡도: O(N³)
- 공간 복잡도: O(N²)
 
> 시작 패턴 두 종류(< 시작, > 시작)을 모두 관리해야 하므로
> 2D DP로는 구조적으로 불가능 → 반드시 `3차원 DP` 필요


## 📂 파일 구조
  ```
daily-algorithms-python/
├── BOJ/
│   └── 1146_zigzag.py
└── ...
  ```

## 🔖 관련 이슈
Closes #10  