### PR TITLE
feat: solve BOJ 1480 using dfs + bitmask dp

### DIFF
--- a/BOJ/10539_restore_sequence.py
+++ b/BOJ/10539_restore_sequence.py
@@ -1,0 +1,11 @@
+import sys
+input = sys.stdin.readline
+n = int(input().strip())
+B = list(map(int, input().split()))
+A = []
+prefix_sum = 0
+for i in range(n):
+    current = B[i] * (i + 1) - prefix_sum
+    A.append(current)
+    prefix_sum += current
+print(*A)


### PR DESCRIPTION
## 🧩 문제 정보
**플랫폼:** BOJ  
**번호:** 1480  
**제목:** 보석 모으기  
**링크:** https://www.acmicpc.net/problem/1480  

## ✨ 해결 방법

> **DFS + 비트마스크 + LRU Cache 기반의 탑다운 DP를 사용하여 보석을 최대한 많이 담는 경우의 수를 계산했다.**

- 상태 정의: `dfs(bag, used_mask, remain_capacity)`
  - `bag` : 현재 사용하는 가방 번호
  - `used_mask` : 지금까지 사용한 보석 비트마스크
  - `remain_capacity` : 현재 가방에 남은 용량

- 선택지:
  1) 현재 가방을 종료하고 다음 가방으로 이동  
     → `dfs(bag + 1, used_mask, C)`
  2) 현재 가방에 넣을 수 있는 보석을 하나 선택해서 넣기  
     → `1 + dfs(bag, used_mask | (1<<i), remain - weight[i])`

- 메모이제이션: `@lru_cache(None)` 사용  
- 최종 결과: `dfs(0, 0, C)`  

## ⏱️ 복잡도
- 시간 복잡도: `O(M × 2^N × C × N)`  
- 공간 복잡도: `O(M × 2^N × C)`  
(Python에서는 실제 방문한 상태만 캐싱됨)

## 📂 파일 구조
```
daily-algorithms-python/
├── BOJ/
│ └── 1480_jewels.py
└── ...
```

## 🔖 관련 이슈
Closes #14 
