### PR TITLE
feat: solve boj 9663 using bitmask backtracking

### DIFF
--- a/BOJ/9663_nqueen.py
+++ b/BOJ/9663_nqueen.py
@@ -1,0 +1,30 @@
+import sys
+sys.setrecursionlimit(10**7)
+
+def main():
+    n = int(sys.stdin.readline().strip())
+    mask = (1 << n) - 1
+    ans = 0
+
+    def dfs(row, cols, diag1, diag2):
+        nonlocal ans
+        if row == n:
+            ans += 1
+            return
+
+        available = mask & ~(cols | diag1 | diag2)
+        while available:
+            pick = available & -available
+            available -= pick
+            dfs(
+                row + 1,
+                cols | pick,
+                ((diag1 | pick) << 1) & mask,  
+                (diag2 | pick) >> 1
+            )
+
+    dfs(0, 0, 0, 0)
+    print(ans)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 🧩 문제 정보
**플랫폼:** BOJ  
**번호:** 9663  
**제목:** N-Queen  
**링크:** https://www.acmicpc.net/problem/9663  


## ✨ 해결 방법

> **행(row) 단위 DFS 백트래킹 + 비트마스크로 충돌 검사 최적화**

각 행에 퀸을 **정확히 1개만 배치**한다고 가정하여 탐색 깊이를 `N`으로 고정하고,  
현재 행에서 놓을 수 있는 열만 선택해 내려가는 **DFS 백트래킹**으로 모든 경우의 수를 탐색했다.

열(`cols`), ↘ 대각선(`diag1`), ↙ 대각선(`diag2`)의 점유 여부를  
**비트마스크(bitmask)** 로 관리하여 유효성 검사를 O(1)에 처리한다.


### 상태 정의
- `dfs(row, cols, diag1, diag2)`
  - `row` : 현재 퀸을 배치할 행
  - `cols` : 사용 중인 열 bitmask
  - `diag1` : ↘ 대각선 점유 bitmask
  - `diag2` : ↙ 대각선 점유 bitmask



### 전이 로직
1. 현재 행에서 가능한 열 계산  
   `available = mask & ~(cols | diag1 | diag2)`

2. 가능한 열 중 하나 선택 (LSB 추출)  
   `pick = available & -available`

3. 다음 행으로 재귀 호출  
   `dfs(row + 1, cols | pick, ((diag1 | pick) << 1) & mask, (diag2 | pick) >> 1)`


### 종료 조건
- `row == N`  
  → N개의 퀸 배치 완료 → 경우의 수 1 증가



## ⏱️ 복잡도 분석
- **시간 복잡도**: 백트래킹 특성상 최악은 매우 크지만, 비트마스크 가지치기로 실제 탐색량 감소
- **공간 복잡도**: O(N) (재귀 호출 스택)



## 📂 파일 구조
```
  daily-algorithms-python/
  ├── BOJ/
  │   └── 1480_jewels.py
  └── ...
```

## 🔖 관련 이슈
Closes #20 