### PR TITLE
feat: solve BOJ 11399 ATM with greedy approach

### DIFF
--- a/BOJ/11399_atm.py
+++ b/BOJ/11399_atm.py
@@ -1,0 +1,18 @@
+import sys
+
+def main():
+    input = sys.stdin.readline
+    n = int(input().strip())
+    p = list(map(int, input().split()))
+    p.sort()
+
+    prefix = 0
+    ans = 0
+    for x in p:
+        prefix += x
+        ans += prefix
+
+    print(ans)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 🧩 문제 정보
**플랫폼:** BOJ  
**번호:** 11399  
**제목:** ATM  
**링크:** https://www.acmicpc.net/problem/11399  


## ✨ 해결 방법

> **각 사람이 인출하는 데 걸리는 시간을 오름차순으로 정렬한 뒤, 누적 대기 시간의 합을 계산하는 Greedy 방식**

이 문제는 각 사람이 기다리는 시간이  
앞선 사람들의 인출 시간 합으로 결정되는 구조이다.

따라서 **짧은 시간이 앞에 올수록**  
뒤에 있는 모든 사람들의 대기 시간이 줄어들어  
전체 대기 시간의 합이 최소가 된다.

### 핵심 아이디어
- 전체 대기 시간의 합 = **누적합(prefix sum)들의 합**
- 인출 시간을 **오름차순 정렬**하면 전체 합이 최소
- 정렬 후 누적합을 한 번만 갱신하며 계산 가능

### 절차
1. 인출 시간 배열 `P`를 오름차순으로 정렬
2. `prefix`(누적 대기 시간), `total`(전체 대기 시간 합) 초기화
3. 정렬된 배열을 순회하며  
   - `prefix += P[i]`  
   - `total += prefix`
4. `total` 출력


## ⏱️ 복잡도
- **시간 복잡도:** `O(N log N)` (정렬)
- **공간 복잡도:** `O(N)` (입력 배열)


## 📂 파일 구조
```
daily-algorithms-python/
├── BOJ/
│ └── 11399_atm.py
└── ...
```



## 🔖 관련 이슈
Closes #24 
