### PR TITLE
feat: solve BOJ 20044 using greedy pairing

### DIFF
--- a/BOJ/20044_project_teams.py
+++ b/BOJ/20044_project_teams.py
@@ -1,0 +1,18 @@
+import sys
+
+input = sys.stdin.readline
+
+n = int(input())
+arr = list(map(int, input().split()))
+
+arr.sort()
+
+l, r = 0, 2 * n - 1
+ans = 10**18
+
+while l < r:
+    ans = min(ans, arr[l] + arr[r])
+    l += 1
+    r -= 1
+
+print(ans)


### PR DESCRIPTION
## 🧩 문제 정보
**플랫폼:** BOJ  
**번호:** 20044  
**제목:** Project Teams  
**링크:** https://www.acmicpc.net/problem/20044  


## ✨ 해결 방법

> **학생 실력을 오름차순 정렬한 뒤, 가장 작은 값과 가장 큰 값을 짝지어 팀을 구성하는 Greedy 방식**

이 문제는 2명씩 팀을 구성했을 때  
**모든 팀 중 최대 팀 실력을 최소화**하는 것이 목표이다.

이를 위해 실력이 가장 낮은 학생과 가장 높은 학생을 한 팀으로 묶으면  
강한 학생이 약한 학생을 보완하게 되어  
특정 팀의 실력이 과도하게 커지는 것을 방지할 수 있다.

### 핵심 아이디어
- 팀 실력 = **두 학생 실력의 합**
- 최대 팀 실력을 최소화해야 함 (Minimize the maximum)
- **정렬 후 양 끝을 매칭하는 Greedy 전략**
- 각 팀의 합 중 **최댓값이 정답**

### 절차
1. 학생 실력 배열을 오름차순으로 정렬
2. 왼쪽 포인터(`l`)와 오른쪽 포인터(`r`) 설정
3. `l < r` 동안 반복하며  
   - 현재 팀 실력 = `A[l] + A[r]`  
   - 최대 팀 실력 갱신  
   - `l += 1`, `r -= 1`
4. 계산된 최대 팀 실력 출력


## ⏱️ 복잡도
- **시간 복잡도:** `O(N log N)` (정렬)
- **공간 복잡도:** `O(N)` (입력 배열)


## 📂 파일 구조
```
daily-algorithms-python/
├── BOJ/
│ └── 20044_project_teams.py
└── ...
```

## 🔖 관련 이슈
Closes #26 