### PR TITLE
feat: solve BOJ 13343 Block Game using greedy euclid strategy

### DIFF
--- a/BOJ/13343_block_game.py
+++ b/BOJ/13343_block_game.py
@@ -1,0 +1,19 @@
+import sys
+def solve():
+    n, m = map(int, sys.stdin.readline().split())
+    a, b = n, m
+    turn = 0  
+    while True:
+        if a < b:
+            a, b = b, a
+        if b == 0:
+            winner = 1 - turn
+            break
+        if a % b == 0 or a >= 2 * b:
+            winner = turn
+            break
+        a = a - b
+        turn ^= 1
+    print("win" if winner == 0 else "lose")
+if __name__ == "__main__":
+    solve()


### PR DESCRIPTION
## 🧩 문제 정보
**플랫폼:** BOJ  
**번호:** 13343  
**제목:** Block Game  
**링크:** https://www.acmicpc.net/problem/13343  


## ✨ 해결 방법

> **유클리드 호제법 형태의 게임을 관찰하여, 현재 턴에서 즉시 승리 가능한 조건을 판별하며 진행하는 Greedy/게임이론 구현**

두 정수 `A, B`가 주어졌을 때(항상 `A ≥ B`로 맞춰 진행),  
현재 턴 플레이어는 `A`에서 `B`를 어떤 양의 정수 배수만큼 빼서 `A' = A - kB (A' ≥ 0)`로 만들 수 있다.

핵심 관찰은 다음 2가지 경우에 **현재 턴에서 즉시 승리**가 가능하다는 점이다.

### ✅ 즉시 승리 조건
1. **`A % B == 0` 인 경우**  
   - `A`를 `B`의 배수만큼 정확히 빼서 0으로 만들 수 있다 → 즉시 종료/승리

2. **`A >= 2B` 인 경우**  
   - `k`를 1보다 크게 선택할 수 있어, 상대에게 유리한 형태를 피하면서 결정적인 상태로 만들 수 있다  
   - 즉, 선택지가 여러 개 생기는 순간 현재 턴이 유리하며 이 조건에서 승리 판정이 가능하다

### ✅ 강제 진행(턴 넘어감) 조건
- **`B < A < 2B` 인 경우**  
  - 가능한 `k`는 오직 1뿐이라서 `A = A - B`로 **강제 진행**된다.
  - 이때는 “결정권”이 없으므로 턴만 넘어가며, 이후 상태로 계속 반복하면 된다.

따라서 매 턴 다음을 반복한다:
- `A < B`면 swap
- `A % B == 0` 또는 `A >= 2B`면 현재 턴 승리
- 아니면 `A -= B` 하고 턴 교대


### 핵심 아이디어
- `A ≥ B`로 유지
- **`A % B == 0` 또는 `A >= 2B`면 현재 턴 즉시 승리**
- **그 외(`B < A < 2B`)는 `A -= B`로 강제 진행 + 턴 교대**
- “win/lose”는 최종 승자(선공 기준)로 출력


### 절차
1. `A, B` 입력
2. 매 턴마다 `A ≥ B` 정렬
3. 즉시 승리 조건 체크:
   - `A % B == 0` 또는 `A >= 2B` → 현재 턴 승리 확정
4. 아니면 `A -= B`, 턴 교대
5. 선공이 이기면 `"win"`, 아니면 `"lose"` 출력


## ⏱️ 복잡도
- **시간 복잡도:** `O(log(max(A,B)))` 수준 (유클리드 진행과 유사)
- **공간 복잡도:** `O(1)`


## 📂 파일 구조
daily-algorithms-python/
```
├── BOJ/
│ └── 13343_block_game.py
└── ...
```

## 🔖 관련 이슈
Closes #28 