### PR TITLE
feat: solve BOJ 1074 Z using divide and conquer

### DIFF
--- a/BOJ/1074_z.py
+++ b/BOJ/1074_z.py
@@ -1,0 +1,31 @@
+import sys
+
+def main():
+    N, r, c = map(int, sys.stdin.readline().split())
+    ans = 0
+    size = 1 << N
+
+    while N > 0:
+        half = size >> 1
+        block = half * half
+
+        if r < half and c < half:
+            pass
+        elif r < half and c >= half:
+            ans += block
+            c -= half
+        elif r >= half and c < half:
+            ans += block * 2
+            r -= half
+        else:
+            ans += block * 3
+            r -= half
+            c -= half
+
+        size = half
+        N -= 1
+
+    sys.stdout.write(str(ans))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 🧩 문제 정보
**플랫폼:** BOJ  
**번호:** 1074  
**제목:** Z  
**링크:** https://www.acmicpc.net/problem/1074  


## ✨ 해결 방법

> **배열을 실제로 생성하지 않고, 분할 정복으로 좌표가 속한 사분면을 추적하는 방식**

이 문제는 `2^N × 2^N` 배열을 Z-order로 탐색할 때  
좌표 `(r, c)`가 **몇 번째로 방문되는지**를 구하는 문제이다.

전체 배열을 만들거나 직접 순회하면 메모리/시간 면에서 비효율적이므로,  
각 단계마다 배열을 4개의 사분면으로 나누고  
`(r, c)`가 속한 사분면의 **방문 순서 오프셋만 누적**하는 방식으로 해결한다.

### 핵심 아이디어
- 한 단계마다 배열은 4개의 사분면으로 분할
- 각 사분면은 고정된 방문 순서 오프셋을 가짐
- `(r, c)`가 속한 사분면을 판별하여 오프셋 누적
- 좌표를 사분면 기준으로 재조정하며 반복
- 배열을 끝까지 쪼개면 누적값이 정답

### 절차
1. `N, r, c` 입력
2. 현재 배열 크기를 `2^N`으로 설정
3. `N > 0` 동안 반복:
   - 현재 배열을 4분할
   - `(r, c)`가 속한 사분면 판별
   - 해당 사분면의 방문 순서 오프셋 누적
   - 좌표를 사분면 기준으로 변환
   - `N` 감소
4. 누적된 방문 순서 출력


## ⏱️ 복잡도
- **시간 복잡도:** `O(N)`
- **공간 복잡도:** `O(1)`


## 📂 파일 구조
```
daily-algorithms-python/
├── BOJ/
│ └── 1074_z.py
└── ...
```


## 🔖 관련 이슈
Closes #30 